### PR TITLE
4.2.0 MOLIM-144 translation quotes fix

### DIFF
--- a/mollie.php
+++ b/mollie.php
@@ -338,7 +338,7 @@ class Mollie extends PaymentModule
 		Media::addJsDef([
 			'description_message' => $this->l('Description cannot be empty'),
 			'profile_id_message' => $this->l('Wrong profile ID'),
-			'profile_id_message_empty' => $this->l('Profile ID cannot be empty'),
+			'profile_id_message_empty' => addslashes($this->l('Profile ID cannot be empty')),
 			'payment_api' => Mollie\Config\Config::MOLLIE_PAYMENTS_API,
 			'ajaxUrl' => $this->context->link->getAdminLink('AdminMollieAjax'),
 		]);


### PR DESCRIPTION
There was an issue where translation was being passed to as JS variable with quotes without a slash in a string like this 'L'strin exmaple'