### PR TITLE
4.2.0 - Running workflow unit tests on PHP 5.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.1']
+        php-versions: ['5.6', '7.1']
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Current PHPunit does not support PHP 5.6. Closing.