### PR TITLE
4.2.0 | readding file due to it being used in PS 1.6

### DIFF
--- a/views/templates/hook/addjsdef.tpl
+++ b/views/templates/hook/addjsdef.tpl
@@ -1,0 +1,11 @@
+{**
+* Mollie       https://www.mollie.nl
+*
+* @author      Mollie B.V. <info@mollie.nl>
+* @copyright   Mollie B.V.
+* @link        https://github.com/mollie/PrestaShop
+* @license     https://github.com/mollie/PrestaShop/blob/master/LICENSE.md
+*}
+<script type="text/javascript">
+    window.mollieQrEnabled = false;
+</script>


### PR DESCRIPTION
Used in Banks.tsx, but as it always was default, leaving it false.

maybe window.mollieQrEnabled does not need to be defined for that place to not crash?